### PR TITLE
lation_diving: document common hotspot notification issue

### DIFF
--- a/pages/scuba-diving/common.mdx
+++ b/pages/scuba-diving/common.mdx
@@ -30,5 +30,10 @@ If you are unsure where to add the above metadata you must contact the creator t
 ### TextUI does not go away
 You are on an outdated version of ```ox_lib``` and must update to the [latest](https://github.com/overextended/ox_lib/releases/latest).
 
+### Hotspot Phone Notifications
+Not seeing hotspot notifications after setting it in the config? 
+
+This usually means the resources are starting in the wrong order.  Ensure that `lation_diving` is started **after** your phone resource.
+
 ### My issue isn't listed here
 Please open a support ticket in our [Discord](https://discord.gg/9EbY4nM5uu) or email us at support@lationscripts.com.


### PR DESCRIPTION
Seen this question pop up a few times, added it into common issues.
---
### Hotspot Phone Notifications
Not seeing hotspot notifications after setting it in the config? 

This usually means the resources are starting in the wrong order.  Ensure that `lation_diving` is started **after** your phone resource.
